### PR TITLE
Switch recipe view from page sheet to full screen

### DIFF
--- a/LetHimCook/Presentation/Views/ContentView.swift
+++ b/LetHimCook/Presentation/Views/ContentView.swift
@@ -75,7 +75,7 @@ struct ContentView: View {
             )))
             .presentationDetents([.large])
         }
-        .sheet(isPresented: Binding(get: { viewModel.isPresentingRecipe }, set: { viewModel.isPresentingRecipe = $0 })) {
+        .fullScreenCover(isPresented: Binding(get: { viewModel.isPresentingRecipe }, set: { viewModel.isPresentingRecipe = $0 })) {
             RecipeView(viewModel: RecipeViewModel(ingredients: viewModel.ingredients))
         }
     }

--- a/LetHimCook/Presentation/Views/RecipeView.swift
+++ b/LetHimCook/Presentation/Views/RecipeView.swift
@@ -2,9 +2,20 @@ import SwiftUI
 
 struct RecipeView: View {
     @Bindable var viewModel: RecipeViewModel
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Label("Back", systemImage: "chevron.backward")
+                }
+                .labelStyle(.titleAndIcon)
+                Spacer()
+            }
+            .padding(.bottom, 4)
             Text("Recipe")
                 .font(.largeTitle)
                 .bold()


### PR DESCRIPTION
## Summary
- present `RecipeView` as full screen
- add a "Back" button to dismiss the recipe screen

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6884b2b746408321bb33a96efebcceeb