### PR TITLE
Implement recipe persistence and list view

### DIFF
--- a/LetHimCook/Core/DI/AppContainer.swift
+++ b/LetHimCook/Core/DI/AppContainer.swift
@@ -20,6 +20,10 @@ enum AppContainer {
         let repository = FoundationRecipeRepository(modelManager: modelManager)
         let useCase = GetRecipeUseCaseImpl(repository: repository)
 
+        let savedRecipesRepository = UserDefaultsSavedRecipesRepository()
+        let saveUseCase = SaveRecipeUseCaseImpl(repository: savedRecipesRepository)
+        let getSavedUseCase = GetSavedRecipesUseCaseImpl(repository: savedRecipesRepository)
+
         await container.register(Logger.self, scope: .singleton) {
             logger
         }
@@ -34,6 +38,18 @@ enum AppContainer {
 
         await container.register(GetRecipeUseCase.self, scope: .singleton) {
             useCase
+        }
+
+        await container.register(SavedRecipeRepository.self, scope: .singleton) {
+            savedRecipesRepository
+        }
+
+        await container.register(SaveRecipeUseCase.self, scope: .singleton) {
+            saveUseCase
+        }
+
+        await container.register(GetSavedRecipesUseCase.self, scope: .singleton) {
+            getSavedUseCase
         }
 
     }

--- a/LetHimCook/Data/Repositories/UserDefaultsSavedRecipesRepository.swift
+++ b/LetHimCook/Data/Repositories/UserDefaultsSavedRecipesRepository.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+final class UserDefaultsSavedRecipesRepository: SavedRecipeRepository {
+    private let userDefaults: UserDefaults
+    private let key = "saved_recipes"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func fetchRecipes() async -> [Recipe] {
+        guard
+            let data = userDefaults.data(forKey: key),
+            let recipes = try? JSONDecoder().decode([Recipe].self, from: data)
+        else {
+            return []
+        }
+        return recipes
+    }
+
+    func save(recipe: Recipe) async {
+        var recipes = await fetchRecipes()
+        recipes.append(recipe)
+        if let data = try? JSONEncoder().encode(recipes) {
+            userDefaults.set(data, forKey: key)
+        }
+    }
+}

--- a/LetHimCook/Domain/Entities/Recipe.swift
+++ b/LetHimCook/Domain/Entities/Recipe.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-struct Recipe: Sendable {
+struct Recipe: Codable, Sendable {
     let text: String
 }

--- a/LetHimCook/Domain/Repositories/SavedRecipeRepository.swift
+++ b/LetHimCook/Domain/Repositories/SavedRecipeRepository.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol SavedRecipeRepository {
+    func fetchRecipes() async -> [Recipe]
+    func save(recipe: Recipe) async
+}

--- a/LetHimCook/Domain/UseCases/GetSavedRecipesUseCase.swift
+++ b/LetHimCook/Domain/UseCases/GetSavedRecipesUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol GetSavedRecipesUseCase {
+    func execute() async -> [Recipe]
+}
+
+struct GetSavedRecipesUseCaseImpl: GetSavedRecipesUseCase {
+    let repository: SavedRecipeRepository
+
+    func execute() async -> [Recipe] {
+        await repository.fetchRecipes()
+    }
+}

--- a/LetHimCook/Domain/UseCases/SaveRecipeUseCase.swift
+++ b/LetHimCook/Domain/UseCases/SaveRecipeUseCase.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol SaveRecipeUseCase {
+    func execute(recipe: Recipe) async
+}
+
+struct SaveRecipeUseCaseImpl: SaveRecipeUseCase {
+    let repository: SavedRecipeRepository
+
+    func execute(recipe: Recipe) async {
+        await repository.save(recipe: recipe)
+    }
+}

--- a/LetHimCook/Presentation/ViewModels/MyRecipesViewModel.swift
+++ b/LetHimCook/Presentation/ViewModels/MyRecipesViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftUI
+import ActorDI
+
+@Observable
+@MainActor
+final class MyRecipesViewModel {
+    private var getSavedRecipesUseCase: GetSavedRecipesUseCase?
+    private(set) var recipes: [Recipe] = []
+
+    init() {
+        Task { [weak self] in
+            self?.getSavedRecipesUseCase = try? await AppContainer.container.resolve(GetSavedRecipesUseCase.self)
+            await self?.loadRecipes()
+        }
+    }
+
+    func loadRecipes() async {
+        guard let getSavedRecipesUseCase else { return }
+        recipes = await getSavedRecipesUseCase.execute()
+    }
+}

--- a/LetHimCook/Presentation/ViewModels/RecipeViewModel.swift
+++ b/LetHimCook/Presentation/ViewModels/RecipeViewModel.swift
@@ -13,6 +13,7 @@ final class RecipeViewModel {
     }
 
     private var getRecipeUseCase: GetRecipeUseCase?
+    private var saveRecipeUseCase: SaveRecipeUseCase?
     private(set) var state: State = .idle
     private let ingredients: [String]
 
@@ -20,6 +21,7 @@ final class RecipeViewModel {
         self.ingredients = ingredients
         Task { [weak self] in
             self?.getRecipeUseCase = try? await AppContainer.container.resolve(GetRecipeUseCase.self)
+            self?.saveRecipeUseCase = try? await AppContainer.container.resolve(SaveRecipeUseCase.self)
             await self?.loadRecipe()
         }
     }
@@ -31,6 +33,7 @@ final class RecipeViewModel {
         do {
             let recipe = try await getRecipeUseCase.execute(with: ingredients)
             state = .success(recipe.text)
+            await saveRecipeUseCase?.execute(recipe: recipe)
         } catch {
             state = .failure("Failed to load recipe.")
         }

--- a/LetHimCook/Presentation/Views/MyRecinseView.swift
+++ b/LetHimCook/Presentation/Views/MyRecinseView.swift
@@ -1,9 +1,19 @@
 import SwiftUI
 
 struct MyRecinseView: View {
+    @Bindable var viewModel = MyRecipesViewModel()
+
     var body: some View {
-        Color(.systemBackground)
-            .ignoresSafeArea()
+        NavigationStack {
+            List(viewModel.recipes.indices, id: \.self) { index in
+                Text(.init(viewModel.recipes[index].text))
+                    .lineLimit(2)
+            }
+            .navigationTitle("My Recipes")
+        }
+        .task {
+            await viewModel.loadRecipes()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- make `Recipe` codable for storage
- add saved recipes repository and related use cases
- store generated recipes in `UserDefaults`
- register new dependencies in `AppContainer`
- update `RecipeViewModel` to persist recipes
- implement view model for listing saved recipes
- display saved recipes in `MyRecinseView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6884cf595edc8321a75cd80f5d0560df