### PR TITLE
Implement Core Data persistence

### DIFF
--- a/LetHimCook/Core/DI/AppContainer.swift
+++ b/LetHimCook/Core/DI/AppContainer.swift
@@ -20,7 +20,7 @@ enum AppContainer {
         let repository = FoundationRecipeRepository(modelManager: modelManager)
         let useCase = GetRecipeUseCaseImpl(repository: repository)
 
-        let savedRecipesRepository = UserDefaultsSavedRecipesRepository()
+        let savedRecipesRepository = CoreDataSavedRecipesRepository()
         let saveUseCase = SaveRecipeUseCaseImpl(repository: savedRecipesRepository)
         let getSavedUseCase = GetSavedRecipesUseCaseImpl(repository: savedRecipesRepository)
 

--- a/LetHimCook/Data/CoreData/PersistenceController.swift
+++ b/LetHimCook/Data/CoreData/PersistenceController.swift
@@ -1,0 +1,41 @@
+import Foundation
+import CoreData
+
+final class PersistenceController {
+    static let shared = PersistenceController()
+    let container: NSPersistentContainer
+
+    private init(inMemory: Bool = false) {
+        let model = NSManagedObjectModel()
+        // Define entity
+        let recipeEntity = NSEntityDescription()
+        recipeEntity.name = "RecipeEntity"
+        recipeEntity.managedObjectClassName = NSStringFromClass(RecipeEntity.self)
+        let textAttribute = NSAttributeDescription()
+        textAttribute.name = "text"
+        textAttribute.attributeType = .stringAttributeType
+        textAttribute.isOptional = false
+        recipeEntity.properties = [textAttribute]
+        model.entities = [recipeEntity]
+
+        container = NSPersistentContainer(name: "RecipeModel", managedObjectModel: model)
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+    }
+
+    static var preview: PersistenceController = {
+        let controller = PersistenceController(inMemory: true)
+        return controller
+    }()
+}
+
+@objc(RecipeEntity)
+final class RecipeEntity: NSManagedObject {
+    @NSManaged var text: String
+}

--- a/LetHimCook/Data/Repositories/CoreDataSavedRecipesRepository.swift
+++ b/LetHimCook/Data/Repositories/CoreDataSavedRecipesRepository.swift
@@ -1,0 +1,30 @@
+import Foundation
+import CoreData
+
+final class CoreDataSavedRecipesRepository: SavedRecipeRepository {
+    private let viewContext: NSManagedObjectContext
+
+    init(container: NSPersistentContainer = PersistenceController.shared.container) {
+        self.viewContext = container.viewContext
+    }
+
+    func fetchRecipes() async -> [Recipe] {
+        let request = NSFetchRequest<RecipeEntity>(entityName: "RecipeEntity")
+        do {
+            let entities = try viewContext.fetch(request)
+            return entities.compactMap { Recipe(text: $0.text) }
+        } catch {
+            return []
+        }
+    }
+
+    func save(recipe: Recipe) async {
+        let entity = RecipeEntity(context: viewContext)
+        entity.text = recipe.text
+        do {
+            try viewContext.save()
+        } catch {
+            print("Failed to save: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Core Data stack for storing recipes
- add `CoreDataSavedRecipesRepository` implementation
- use the new repository in `AppContainer`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6884d4ef27d4832182d82c608a15b3c8